### PR TITLE
File.open モードをバイナリに変更する

### DIFF
--- a/lib/xlsx_templater/xlsx_creator.rb
+++ b/lib/xlsx_templater/xlsx_creator.rb
@@ -12,7 +12,7 @@ module XlsxTemplater
     end
 
     def generate_xlsx_file(file_name = "output_#{Time.now.strftime('%Y-%m-%d_%H%M')}.xlsx")
-      File.open(file_name, 'w') do |f|
+      File.open(file_name, 'wb') do |f|
         f.write(generate_xlsx_bytes.string)
       end
     end


### PR DESCRIPTION
## 背景
`ruby-xlsx-templater`は`rubyzip` gem に依存している

CLINICS本体の`rubyzip`gemを2.3.0にアップデートしたところ、以下のエラーが発生した
- https://github.com/medley-inc/medley-clinic/pull/30036

```
     Encoding::UndefinedConversionError:
       "\x84" from ASCII-8BIT to UTF-8
```

2.3.0のアップデートに含まれるエンコーディング結果がASCII-8BITに変更されたことが原因で、エラーが発生することになった
  * https://github.com/rubyzip/rubyzip/pull/439
  *  File.openでは、デフォルトでUTF-8で書き込もうとするため、コンバートエラーが発生した


以下のように生成されるファイルの中身が変更になっている

#### アップデート前


```
[1] pry(#<XlsxTemplater::XlsxCreator>)> generate_xlsx_bytes.string
=> "PK\u0003\u0004\u0014\u0000\u0000\u0000\b\u0000\a\u007F\x84Xf\xAA\x82\xB7\xE0\u0000\u0000\u0000;\u0002\u0000\u0000\v\u0000\u0000\u0000_rels/.rels\xAD\x92\xCFJ\u00031\u0010\x87\xEF}\x8A\x90{w\xB6\u0015Dd\xB3\xBD\x88ЛH}\x80\x98\xCC\xFEa7\x990\u0019u}{\x83\bZ\xA9\xA5\a\x8FI~\xF3\xCD7C\x9A\xDD\u0012f\xF5\x8A\x9CG\x8AFo\xAAZ+\x8C\x8E\xFC\u0018{\xA3\x9F\u000E\xF7\xEB\e\xBDkW\xCD#\xCEVJ$\u000Fcʪ\xD4\xC4l\xF4 \x92n\u0001\xB2\e0\xD8\\Q\xC2X^:\xE2`\xA5\u001C\xB9\x87d\xDDd{\x84m]_\u0003\xFFd\xE8\xF6\x88\xA9\xF6\xDEh\xDE\xFB\x8DV\x87\xF7\x84\x97\xB0\xA9\xEBF\x87w\xE4^\u0002F9\xD1\xE2W\xA2\x90-\xF7(F/3\xBC\u0011O\xCFDSU\xA0\u001AN\xBBl/w\xF9{N\b(\xD6[\xB1\xE0\x88q\x9D\xB8T\xB3\x8C\x98\xBFu<\xB9\x87r\x9D?\u0013焮\xFEs9\xB8\bF\x8F\xFE\xBC\x92M\xE9\xCBh\xD5\xC0\xD1'h?\u0000PK\u0003\u0004\u0014\u0000\u0000\u0000\b\u0000\a\u007F\x84XO\xF0\xF9z\xD2\u0000\u0000\u0000%\u0002\u0000\u0000\u001A\u0000\u0000\u0000xl/_rels/workbook.xml.rels

...(略)...
```

#### アップデート後
```
[1] pry(#<XlsxTemplater::XlsxCreator>)> generate_xlsx_bytes.string
=> "PK\x03\x04\x14\x00\x00\x00\b\x00*~\x84Xf\xAA\x82\xB7\xE0\x00\x00\x00;\x02\x00\x00\v\x00\x00\x00_rels/.rels\xAD\x92\xCFJ\x031\x10\x87\xEF}\x8A\x90{w\xB6\x15Dd\xB3\xBD\x88\xD0\x9BH}\x80\x98\xCC\xFEa7\x990\x19u}{\x83\bZ\xA9\xA5\a\x8FI~\xF3\xCD7C\x9A\xDD\x12f\xF5\x8A\x9CG\x8AFo\xAAZ+\x8C\x8E\xFC\x18{\xA3\x9F\x0E\xF7\xEB\e\xBDkW\xCD#\xCEVJ$\x0Fc\xCA\xAA\xD4\xC4l\xF4 \x92n\x01\xB2\e0\xD8\\Q\xC2X^:\xE2`\xA5\x1C\xB9\x87d\xDDd{\x84m]_\x03\xFFd\xE8\xF6\x88\xA9\xF6\xDEh\xDE\xFB\x8DV\x87\xF7\x84\x97\xB0\xA9\xEBF\x87w\xE4^\x02F9\xD1\xE2W\xA2\x90-\xF7(F/3\xBC\x11O\xCFDSU\xA0\x1AN\xBBl/w\xF9{N\b(\xD6[\xB1\xE0\x88q\x9D\xB8T\xB3\x8C\x98\xBFu<\xB9\x87r\x9D?\x13\xE7\x84\xAE\xFEs9\xB8\bF\x8F\xFE\xBC\x92M\xE9\xCBh\xD5\xC0\xD1'h?\x00PK\x03\x04\x14\x00\x00\x00\b\x00*~\x84XO\xF0\xF9z\xD2\x00\x00\x00%\x02\x00\x00\x1A\x00\x00\x00xl/_rels/workbook.xml.rels

...(略)...
```

## 対応方針

- Fileには、ASCII-8BITで書き込む
  - [Rubyのエンコーディングその2](https://blog.tmtms.net/entry/20120902/ruby_encoding)
- Windows 10, Macでは、文字コードがUnicodeがデフォルトで採用されているため、Macで開ければ基本的にWindowsでも開ける
